### PR TITLE
feat(compose): вмонтирование схемы БД в контейнер

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,12 +9,13 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - pg_data:/var/lib/postgresql/data
+      - ./backend/DataBase.sql:/docker-entrypoint-initdb.d/init-db.sql
     ports:
       - "${POSTGRES_PORT}:5432"
     networks:
       - scrollic-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U \"testuser\" -d \"testdb\""]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Теперь при поднятии приложения через docker compose БД создается в соответствии со схемой из файлика ./backend/DataBase.sql