### PR TITLE
fix(gateway): нейминг полей и проброс токена в /api/auth/logout

### DIFF
--- a/backend/APIGateway/src/main/java/scrollic/APIGateway/filters/AuthFilter.java
+++ b/backend/APIGateway/src/main/java/scrollic/APIGateway/filters/AuthFilter.java
@@ -23,7 +23,8 @@ public class AuthFilter implements GlobalFilter, Ordered {
 
     private static final List<String> PUBLIC_PATHS = List.of(
             "/api/auth/register",
-            "/api/auth/login"
+            "/api/auth/login",
+            "/api/auth/logout"
     );
 
     @Override

--- a/backend/APIGateway/src/main/java/scrollic/APIGateway/filters/AuthFilter.java
+++ b/backend/APIGateway/src/main/java/scrollic/APIGateway/filters/AuthFilter.java
@@ -45,7 +45,7 @@ public class AuthFilter implements GlobalFilter, Ordered {
                     }
 
                     String userId = (String) sessionData.get("user_id");
-                    String username = (String) sessionData.get("userName");
+                    String username = (String) sessionData.get("user_name");
 
                     if (userId == null || username == null) {
                         return unauthorized(exchange, "Invalid session data");


### PR DESCRIPTION
В процессе разработки возник технический долг в лице нейминга переменных в Redis:
- было: `session:{token} -> Hash: {user_id, userName, expiresAt}`. Что-то через подчеркивание, что-то в CamelCase.
- стало: `session:{token} -> Hash: {user_id, user_name, expires_at}`

В этом PR я сменил нейминг полей, которые ожидает увидеть APIGateway, а так же добавил проброс Bearer Token'а в UserService при запросе `/api/auth/logout`, чтобы последний смог быстро по ключу найти и удалить сессию.