### PR TITLE
build(compose): верхние и нижние границы потребления ресурсов для контейнеров

### DIFF
--- a/backend/APIGateway/Dockerfile
+++ b/backend/APIGateway/Dockerfile
@@ -14,4 +14,4 @@ FROM eclipse-temurin:17-jre
 WORKDIR /app
 
 COPY --from=build /app/build/libs/*.jar app.jar
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-XX:MaxRAMPercentage=70", "-jar", "app.jar"]

--- a/backend/NewsFetcherService/Dockerfile
+++ b/backend/NewsFetcherService/Dockerfile
@@ -14,4 +14,4 @@ FROM eclipse-temurin:17-jre
 WORKDIR /app
 
 COPY --from=build /app/build/libs/*.jar app.jar
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-XX:MaxRAMPercentage=75", "-jar", "app.jar"]

--- a/backend/NewsHandlerService/Dockerfile
+++ b/backend/NewsHandlerService/Dockerfile
@@ -14,4 +14,4 @@ FROM eclipse-temurin:17-jre
 WORKDIR /app
 
 COPY --from=build /app/build/libs/*.jar app.jar
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-XX:MaxRAMPercentage=75", "-jar", "app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,14 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: "512M"
+          cpus: "0.5"
+        reservations:
+          memory: "128M"
+          cpus: "0.2"
 
 
   adminer:
@@ -47,6 +55,14 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: "512M"
+          cpus: "0.8"
+        reservations:
+          memory: "256M"
+          cpus: "0.1"
 
 
   cassandra:
@@ -76,9 +92,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          memory: "3G"
+          cpus: "2.5"
         reservations:
-          memory: 1G
+          memory: "1G"
+          cpus: "0.5"
 
   cassandra-init:
     image: cassandra:5.0
@@ -152,6 +170,14 @@ services:
       timeout: 10s
       retries: 5
       start_period: 40s
+    deploy:
+      resources:
+        limits:
+          memory: "2G"
+          cpus: "2"
+        reservations:
+          memory: "1G"
+          cpus: "1"
 
   kafka-ui:
     image: provectuslabs/kafka-ui:v0.7.2
@@ -191,6 +217,14 @@ services:
       timeout: 5s
       retries: 3
       start_period: 45s
+    deploy:
+      resources:
+        limits:
+          memory: "768M"
+          cpus: "0.5"
+        reservations:
+          memory: "384M"
+          cpus: "0.3"
 
 
   user-service:
@@ -225,6 +259,14 @@ services:
       timeout: 5s
       retries: 3
       start_period: 45s
+    deploy:
+      resources:
+        limits:
+          memory: "512M"
+          cpus: "0.8"
+        reservations:
+          memory: "256M"
+          cpus: "0.2"
 
 
   news-fetcher-service:
@@ -242,6 +284,14 @@ services:
       GNEWS_APIKEY: ${GNEWS_APIKEY}
     networks:
       - scrollic-network
+    deploy:
+      resources:
+        limits:
+          memory: "768M"
+          cpus: "0.5"
+        reservations:
+          memory: "384M"
+          cpus: "0.3"
 
 
   news-handler-service:
@@ -269,6 +319,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    deploy:
+      resources:
+        limits:
+          memory: "768M"
+          cpus: "1"
+        reservations:
+          memory: "384M"
+          cpus: "0.4"
 
 
 volumes:


### PR DESCRIPTION
Необходимо было ограничить потребление ресурсов контейнерами, чтобы не допустить неразумного распределения ресурсов, когда один "голодает", а другой забрал лишнего.

Изменения:
- Всем контейнерам (кроме UI) добавил максимальные и минимальные границы по потреблению ресурсов. Максимальная граница - выше нее контейнер вылезти не может. Минимальная граница - это количество зарезервировано под контейнер всегда. Конкретные цифры можно посмотреть в табличках снизу.
- Для Java микросервисов добавил параметр запуска `-XX:MaxRAMPercentage`, который устанавливает процентное соотношение между кучей (Heap) и всем остальным. Для api-gateway выставил значение в 70%, так как планируется огромное количество одновременных подключений => нужно больше native памяти. Для NewsFetcher и NewsHandler установил 75.

# Нижняя граница
| Сервис | CPU | RAM |
|--------|-----|-----|
| postgres | 0,2 | 128M |
| redis | 0,1 | 256M |
| cassandra | 0,5 | 1G |
| kafka | 1 | 1G |
| adminer | — | — |
| kafka-ui | — | — |
| api-gateway | 0,3 | 384M |
| user-service | 0,2 | 256M |
| feed-service | 0,2 | 256M |
| action-service | 0,2 | 256M |
| news-fetcher | 0,3 | 384M |
| news-handler | 0,4 | 384M |

**Итого:** CPU: 3,4 | RAM: 4,25G

---
# Верхняя граница
| Сервис | CPU | RAM |
|--------|-----|-----|
| postgres | 0,5 | 512M |
| redis | 0,8 | 512M |
| cassandra | 2,5 | 3G |
| kafka | 2 | 2G |
| adminer | — | — |
| kafka-ui | — | — |
| api-gateway | 0,5 | 768M |
| user-service | 0,8 | 512M |
| feed-service | 0,8 | 512M |
| action-service | 0,8 | 512M |
| news-fetcher | 0,5 | 768M |
| news-handler | 1 | 768M |

**Итого:** CPU: 10,2 | RAM: 9,75G

Для Java брал побольше, так как Spring Boot попрожорливей питона будет (само наличие JVM + бины от Spring Boot...)

---
Для корректной работы рекомендую вручную выставить параметры для вашей WSL2. Вот пошаговая инструкция:
1) Открываем Powershell от имени администратора и пишем:
`notepad "$env:USERPROFILE/.wslconfig"`
2) Отредачить или создать файлик с такими параметрами:
```
[wsl2]
memory=10GB # надеюсь у вас у всех 16+....
processors=8 # тут хотябы 6 (если 8 потоков макс у проца), но лучше 8-10
swap=2GB
```
3) Для применения настроек: `wsl --shutdown` и запускаем снова.