### PR TITLE
feat(backend): добавление нового роута для первоначальных весов тем

### DIFF
--- a/backend/ActionService/app/dependencies.py
+++ b/backend/ActionService/app/dependencies.py
@@ -36,3 +36,24 @@ async def get_current_user(
 
     logger.debug(f"Action requested for user: {x_user_id}")
     return x_user_id
+
+
+DEFAULT_THEME_WEIGHTS = {1: 20, 2: 20, 3: 20, 4: 20, 5: 20}
+
+async def set_default_preferences(
+        user_id: int,
+        cassandra_session
+):
+    """Установить дефолтные веса для нового пользователя"""
+    from app.schemas import PreferencesRequest
+    request = PreferencesRequest(theme_weights=DEFAULT_THEME_WEIGHTS)
+
+    delete_query = "DELETE FROM user_theme_weights WHERE user_id = %s"
+    cassandra_session.execute(delete_query, (user_id,))
+
+    insert_query = """
+        INSERT INTO user_theme_weights (user_id, theme_id, weight, updated_at)
+        VALUES (%s, %s, %s, %s)
+    """
+    for theme_id, weight in request.theme_weights.items():
+        cassandra_session.execute(insert_query, (user_id, theme_id, weight, datetime.now()))

--- a/backend/ActionService/app/routers/actions.py
+++ b/backend/ActionService/app/routers/actions.py
@@ -6,7 +6,8 @@ from uuid import UUID
 from datetime import datetime
 from app.schemas import (
     BatchActions, BatchResponse, ActionResponse,
-    ActionStatusResponse, LikeRequest, SeenRequest, UnlikeRequest
+    ActionStatusResponse, LikeRequest, SeenRequest, UnlikeRequest,
+    PreferencesRequest
 )
 from app.dependencies import get_current_user, get_redis
 from app.database import get_cassandra
@@ -315,3 +316,100 @@ async def recalculate_weights(
     except Exception as e:
         logger.error(f"Error recalculating weights: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/preferences")
+async def set_user_preferences(
+        request: PreferencesRequest,
+        user_id: int = Depends(get_current_user),
+        cassandra_session=Depends(get_cassandra),
+        redis_client=Depends(get_redis)
+):
+    """
+    Установить предпочтения пользователя (избранные категории).
+    Вызывается после регистрации для инициализации весов тем.
+    """
+    try:
+        if not cassandra_session:
+            raise HTTPException(status_code=503, detail="Cassandra not available")
+
+        # Нормализуем веса (чтобы сумма была 100)
+        total = sum(request.theme_weights.values())
+        if total != 100:
+            # Нормируем к 100%
+            normalized_weights = {
+                theme_id: (weight / total) * 100
+                for theme_id, weight in request.theme_weights.items()
+            }
+            logger.info(f"Normalized weights from sum={total} to 100: {normalized_weights}")
+        else:
+            normalized_weights = request.theme_weights
+
+        # Удаляем старые веса пользователя
+        delete_query = "DELETE FROM user_theme_weights WHERE user_id = %s"
+        cassandra_session.execute(delete_query, (user_id,))
+
+        # Сохраняем новые веса
+        insert_query = """
+            INSERT INTO user_theme_weights (user_id, theme_id, weight, updated_at)
+            VALUES (%s, %s, %s, %s)
+        """
+        for theme_id, weight in normalized_weights.items():
+            cassandra_session.execute(insert_query, (user_id, theme_id, weight, datetime.now()))
+
+        logger.info(f"Saved preferences for user {user_id}: {normalized_weights}")
+
+        # Инвалидируем кэш FeedService (чтобы лента обновилась с новыми весами)
+        from app.services.weight_recalculator import WeightRecalculator
+        recalculator = WeightRecalculator(cassandra_session)
+        await recalculator._invalidate_feed_cache(user_id)
+
+        # Если Redis доступен, очистим кэш статусов для этого пользователя
+        if redis_client:
+            keys = redis_client.keys(f"action_status:{user_id}:*")
+            if keys:
+                redis_client.delete(*keys)
+                logger.info(f"Invalidated {len(keys)} action status cache keys for user {user_id}")
+
+        return {
+            "status": "success",
+            "message": "User preferences saved successfully",
+            "user_id": user_id,
+            "weights": normalized_weights
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error saving preferences for user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/preferences")
+async def get_user_preferences(
+        user_id: int = Depends(get_current_user),
+        cassandra_session=Depends(get_cassandra)
+):
+    """
+    Получить текущие предпочтения пользователя (веса тем).
+    """
+    try:
+        if not cassandra_session:
+            raise HTTPException(status_code=503, detail="Cassandra not available")
+
+        query = "SELECT theme_id, weight FROM user_theme_weights WHERE user_id = %s"
+        rows = cassandra_session.execute(query, (user_id,))
+
+        weights = {row['theme_id']: float(row['weight']) for row in rows}
+
+        return {
+            "status": "success",
+            "user_id": user_id,
+            "weights": weights
+        }
+
+    except Exception as e:
+        logger.error(f"Error getting preferences for user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+

--- a/backend/ActionService/app/schemas.py
+++ b/backend/ActionService/app/schemas.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 from uuid import UUID
-from typing import List, Optional
+from typing import List, Optional, Dict
 from datetime import datetime
 
 
@@ -54,3 +54,7 @@ class SeenRequest(BaseModel):
 
 class UnlikeRequest(BaseModel):
     news_id: UUID
+
+
+class PreferencesRequest(BaseModel):
+    theme_weights: Dict[int, float]  # {theme_id: weight}


### PR DESCRIPTION
1. Регистрация

- Пользователь вводит логин и пароль
- Мобилка отправляет запрос в UserService
- UserService создаёт пользователя
- Мобилка получает токен и ID пользователя

2. Показ экрана выбора

- Мобилка показывает список тем
- Пользователь выбирает любимые темы

3. Отправка весов

- Мобилка отправляет POST запрос в ActionService
- Адрес: /api/actions/preferences
- Заголовок: X-User-Id = ID пользователя
- Тело: веса тем {"1": 50, "2": 30, "3": 20}

curl -X POST "http://localhost:8002/api/actions/preferences" \
  -H "X-User-Id: 4" \
  -H "Content-Type: application/json" \
  -d '{"theme_weights": {"1": 50, "2": 30, "3": 20}}'

4. Сохранение в базу

- ActionService получает веса
- Сохраняет их в Cassandra в таблицу user_theme_weights
- Старые веса удаляются, новые записываются

5. Готово

- Мобилка получает ответ "успешно"
- Пользователь переходит на главный экран
- Лента формируется по выбранным темам